### PR TITLE
Confirmation before performing Export database operation when there is no data

### DIFF
--- a/app/src/main/java/info/zamojski/soft/towercollector/preferences/AdvancedPreferenceFragment.java
+++ b/app/src/main/java/info/zamojski/soft/towercollector/preferences/AdvancedPreferenceFragment.java
@@ -26,6 +26,8 @@ import info.zamojski.soft.towercollector.dev.PreferencesOperations;
 import info.zamojski.soft.towercollector.utils.StorageUtils;
 import timber.log.Timber;
 
+import info.zamojski.soft.towercollector.dao.MeasurementsDatabase;
+
 public class AdvancedPreferenceFragment extends DialogEnabledPreferenceFragment implements OnSharedPreferenceChangeListener {
 
     private ListPreference collectorApiVersionPreference;
@@ -57,13 +59,25 @@ public class AdvancedPreferenceFragment extends DialogEnabledPreferenceFragment 
     }
 
     private void setupDatabaseExport() {
-        setupOnClick(R.string.preferences_export_database_key, new Preference.OnPreferenceClickListener() {
-            @Override
-            public boolean onPreferenceClick(Preference preference) {
-                exportDatabase();
-                return true;
-            }
-        });
+        // get number of locations to upload
+        int locationsCount = MeasurementsDatabase.getInstance(MyApplication.getApplication()).getAllLocationsCount(true);
+        if (locationsCount == 0) {
+            showConfirmationDialog(R.string.preferences_export_database_key, R.string.database_export_warning_title,
+                    R.string.database_export_warning_message, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            exportDatabase();
+                        }
+                    });
+        } else {
+            setupOnClick(R.string.preferences_export_database_key, new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                 exportDatabase();
+                 return true;
+                }
+            });
+        }
     }
 
     private void setupPreferencesImport() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,8 @@
     <string name="reupload_measurements_if_upload_fails_for_one_of_projects">Try to upload measurements again if upload fails for one of the projects</string>
     <string name="unsafe_operation_warning_title">Unsafe operation</string>
     <string name="unsafe_operation_warning_message">This option can break the app\'s configuration and result in crash. In such case you have to clear the app data in Android settings. You need to fully close and reopen the app to see the changes!\n\nYou use it on your own risk!</string>
+    <string name="database_export_warning_title">Export empty database</string>
+    <string name="database_export_warning_message">Proceeding with this operation will overwrite the measurements.db file with an empty state.\n\nAre you sure you want to export?</string>
     <string name="database_import_message">Database imported</string>
     <string name="database_export_message">Database exported</string>
     <string name="database_import_export_failed_message">Database operation failed</string>


### PR DESCRIPTION
Display a warning when attempting an Export Database operation when there is no data pending upload