### PR TITLE
Warn that GPS parameters optimization may cause dropped measurements …

### DIFF
--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -62,7 +62,7 @@
     <string name="preferences_collector_keep_screen_on_title">Keep screen on when collecting</string>
     <string name="preferences_collector_keep_screen_on_summary">Defines if screen will be kept constantly on while collecting measurements. Enabling will significantly shorten battery life.</string>
     <string name="preferences_gps_optimizations_enabled_title">Collector GPS optimization</string>
-    <string name="preferences_gps_optimizations_enabled_on_summary">GPS parameters optimization will be used when collecting measurements.</string>
+    <string name="preferences_gps_optimizations_enabled_on_summary">GPS parameters optimization will be used when collecting measurements. Enabling may cause some dropped measurements on some devices when moving at high speeds.</string>
     <string name="preferences_gps_optimizations_enabled_off_summary">GPS parameters optimization is disabled.</string>
     <string name="preferences_export_compression_format_title">Compression format</string>
     <string name="preferences_export_compression_format_summary">Defines compression format of exported files.</string>


### PR DESCRIPTION
…on some devices when moving at high speeds.

For #180. (Which @zamojski might be missing notifications of).

Yes, tracing through the code, one finds

```
transportMode = (MyApplication.getPreferencesProvider().getGpsOptimizationsEnabled() ? MeansOfTransport.Universal : MeansOfTransport.Fixed);
```
and in CollectorService.java, things like

```
Timber.d("updateDynamicInterval(): Skipping GPS reconnection because of too small interval difference: %s", intervalDiff);
...
int newInterval = Math.min(currentIntervalValue.get() + 500, transportMode.getMaxTime());
```